### PR TITLE
A few small improvements to the 'Import Projects from Folder...' wizard

### DIFF
--- a/plugins/org.jboss.tools.playground.easymport/src/org/jboss/tools/playground/easymport/EasymportWizard.java
+++ b/plugins/org.jboss.tools.playground.easymport/src/org/jboss/tools/playground/easymport/EasymportWizard.java
@@ -6,9 +6,10 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.jface.dialogs.DialogSettings;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IImportWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkingSet;
@@ -34,7 +35,6 @@ public class EasymportWizard extends Wizard implements IImportWizard {
 				}
 			}
 		}
-		setDialogSettings(new DialogSettings(getClass().getName()));
 	}
 	
 	private File toFile(Object o) {
@@ -69,8 +69,27 @@ public class EasymportWizard extends Wizard implements IImportWizard {
 
 	@Override
 	public boolean performFinish() {
-		new OpenFolderCommand().importProjectsFromDirectory(this.page.getSelectedRootDirectory(), this.page.getSelectedWorkingSets());
+		getDialogSettings().put(EasymportWizardPage.ROOT_DIRECTORY, page.getSelectedRootDirectory().getAbsolutePath());
+		final File directory = this.page.getSelectedRootDirectory();
+		final Set<IWorkingSet> workingSets = this.page.getSelectedWorkingSets();
+		Display.getCurrent().asyncExec(new Runnable() {
+			
+			@Override
+			public void run() {
+				new OpenFolderCommand().importProjectsFromDirectory(directory, workingSets);
+			}
+		});
 		return true;
+	}
+
+	@Override
+	public IDialogSettings getDialogSettings() {
+		IDialogSettings dialogSettings = super.getDialogSettings();
+		if (dialogSettings == null) {
+			dialogSettings = Activator.getDefault().getDialogSettings();
+			setDialogSettings(dialogSettings);
+		}
+		return dialogSettings;
 	}
 
 }

--- a/plugins/org.jboss.tools.playground.easymport/src/org/jboss/tools/playground/easymport/EasymportWizardPage.java
+++ b/plugins/org.jboss.tools.playground.easymport/src/org/jboss/tools/playground/easymport/EasymportWizardPage.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
@@ -11,7 +12,6 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -25,6 +25,7 @@ import org.eclipse.ui.dialogs.WorkingSetConfigurationBlock;
 
 public class EasymportWizardPage extends WizardPage {
 
+	public static final String ROOT_DIRECTORY = "rootDirectory";
 	private File selection;
 	private Set<IWorkingSet> workingSets;
 	private ControlDecoration rootDirectoryTextDecorator;
@@ -45,7 +46,7 @@ public class EasymportWizardPage extends WizardPage {
 		Label rootDirectoryLabel = new Label(res, SWT.NONE);
 		rootDirectoryLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 		rootDirectoryLabel.setText(Messages.EasymportWizardPage_selectRootDirectory);
-		Text rootDirectoryText = new Text(res, SWT.BORDER);
+		final Text rootDirectoryText = new Text(res, SWT.BORDER);
 		rootDirectoryText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		rootDirectoryText.addModifyListener(new ModifyListener() {
 			@Override
@@ -58,14 +59,21 @@ public class EasymportWizardPage extends WizardPage {
 		this.rootDirectoryTextDecorator.setImage(getShell().getDisplay().getSystemImage(SWT.ERROR));
 		this.rootDirectoryTextDecorator.setDescriptionText(Messages.EasymportWizardPage_incorrectRootDirectory);
 		this.rootDirectoryTextDecorator.hide();
-		Button browseButton = new Button(res, SWT.BORDER);
+		IDialogSettings dialogSettings = getDialogSettings();
+		String rootDirectory = dialogSettings.get(ROOT_DIRECTORY);
+		if (rootDirectory != null) {
+			rootDirectoryText.setText(rootDirectory);
+		}
+		Button browseButton = new Button(res, SWT.PUSH);
 		browseButton.setText(Messages.EasymportWizardPAge_browse);
 		browseButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				DirectoryDialog dialog = new DirectoryDialog(getShell());
+				dialog.setText(rootDirectoryText.getText());
 				String res = dialog.open();
 				if (res != null) {
+					rootDirectoryText.setText(res);
 					EasymportWizardPage.this.selection = new File(res);
 					EasymportWizardPage.this.validatePage();
 				}


### PR DESCRIPTION
I have added several improvements to the "Import Projects from Folder..." wizard

- now, the Browse button is created with the SWT.PUSH instead of SWT.BORDER flag
- when browsing a root directory, the rootDirectoryText field is updated
- adding dialog settings for a root directory
- clicking the Finish button closes the wizard and the OpenFolderCommand action is called in the background. Otherwise, the user wouldn't see the action's progress dialog.